### PR TITLE
Agregamos enlace de Canva al README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+[Ver diseño en Canva](https://www.canva.com/design/tu-enlace-aquí)


### PR DESCRIPTION
Se agregó un enlace al diseño de Canva en el archivo README.md para facilitar el acceso al prototipo visual del proyecto. Este prototipo solo es una idea de como se mostraría visualmente el proyecto de la landing page promocional de la cafetería.   